### PR TITLE
Fix Issue #4: No message when Google Assistant responds with None

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -14,9 +14,9 @@ queries are handled by a Neural Network on Google cloud servers.
 Help is the only hardcoded command.'''
 
 ERROR_MESSAGE = '''Sorry, I can't help with that yet'''
-FAIL_MESSAGE = '''It seems that you have disabled your 
-personalized responses for Google Assistant. Please enable them
-to receive appropiate response from the bot. '''
+FAIL_MESSAGE = '''It seems that personalized response are
+disabled. No responses would be receieved until the
+personalized responses are enabled again.'''
 
 
 class AssistantDiscordBot(AutoShardedBot):

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,9 @@ queries are handled by a Neural Network on Google cloud servers.
 Help is the only hardcoded command.'''
 
 ERROR_MESSAGE = '''Sorry, I can't help with that yet'''
+FAIL_MESSAGE = '''It seems that you have disabled your 
+personalized responses for Google Assistant. Please enable them
+to receive appropiate response from the bot. '''
 
 
 class AssistantDiscordBot(AutoShardedBot):
@@ -61,6 +64,8 @@ class AssistantDiscordBot(AutoShardedBot):
 
         if assistant_response:
             await message.channel.send(assistant_response)
+        else:
+            await message.channel.send(FAIL_MESSAGE)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Previously, if the Google Assistant API failed to return a response (resulting in a none type), then the bot wouldn't function as expected and wouldn't display any message to the end user informing them that the API failed to provide a response. This issue as quoted by the developer was being caused mostly when the service google account being used to operate the google assistant API had personalized responses disabled. This PR adds a message informing the end user of the failure.

Fixes Issue #4 

 